### PR TITLE
Define the methods to quack like a logger

### DIFF
--- a/lib/null_logger.rb
+++ b/lib/null_logger.rb
@@ -1,32 +1,69 @@
 # frozen_string_literal: true
 
-# Null logger class
-# Is used when logger is not defined
+# Null logger class. This is essentially the same as sending data down the
+# `/dev/null` blackhole.
+#
+# @example Basic Usage
+#
+#   logger = NullLogger.new
+#   Rails.logger = logger
+#
+#
+# @example Basic Pattern Usage
+#   class SomeService
+#     def initialize(options = {})
+#       @logger = options[:logger] || NullLogger.new
+#     end
+#
+#     def perform
+#       @logger.debug -> { "do some work here" }
+#       # .. ..
+#       @logger.info -> { "finished working" }
+#     end
+#   end
+#
+#   service = SomeService.new(logger: Logger.new(STDOUT))
+#   service.perform
+#
+#   silent = SomeService.new(logger: NullLogger.new
+#   silent.perform
+#
 class NullLogger
-  # Possible log levels from ruby Logger::Severity class
-  LOG_LEVELS = %w[
-    unknown
-    fatal
-    error
-    warn
-    info
-    debug
-  ].freeze
-
-  # @return [Boolean] true if we can handle this missing method, otherwise false
-  # @param method_name [String, Symbol] method name
-  # @param include_private [Boolean] should we include private methods as well
-  def respond_to_missing?(method_name, include_private = false)
-    LOG_LEVELS.include?(method_name.to_s) || super
+  def unknown(*)
   end
 
-  # Returns nil for any method call from LOG_LEVELS array
-  # Instead raise NoMethodError
-  # @example:
-  #   NullLogger.new.fatal -> return nil
-  #   NullLogger.new.wrong_method -> raise NoMethodError
-  def method_missing(method_name, *args, &block)
-    return nil if LOG_LEVELS.include?(method_name.to_s)
-    super
+  def fatal(*)
+  end
+
+  def fatal?
+    false
+  end
+
+  def error(*)
+  end
+
+  def error?
+    false
+  end
+
+  def warn(*)
+  end
+
+  def warn?
+    false
+  end
+
+  def info(*)
+  end
+
+  def info?
+    false
+  end
+
+  def debug(*)
+  end
+
+  def debug?
+    false
   end
 end

--- a/spec/lib/null_logger_spec.rb
+++ b/spec/lib/null_logger_spec.rb
@@ -1,25 +1,34 @@
 # frozen_string_literal: true
 
 RSpec.describe NullLogger do
+  subject { logger }
+
   let(:logger) { described_class.new }
 
-  context 'logs level handling' do
-    it 'return nil if call method from LOG_LEVELS array' do
-      expect(logger.warn).to be nil
-    end
+  it { is_expected.to respond_to(:unknown) }
+  it { is_expected.to respond_to(:fatal) }
+  it { is_expected.to respond_to(:error) }
+  it { is_expected.to respond_to(:warn) }
+  it { is_expected.to respond_to(:info) }
+  it { is_expected.to respond_to(:debug) }
 
-    it 'raise exception if call method which not exist in LOG_LEVELS array' do
-      expect { logger.warnnnn }.to raise_error(NoMethodError)
-    end
+  it 'returns false for debug?' do
+    expect(logger.debug?).to be_falsey
   end
 
-  describe '#respond_to_missing?' do
-    context 'when this is a log level' do
-      it { expect(logger.send(:respond_to_missing?, :warn)).to be true }
-    end
+  it 'returns false for info?' do
+    expect(logger.info?).to be_falsey
+  end
 
-    context 'when this is not a log level' do
-      it { expect(logger.send(:respond_to_missing?, :warnnnn)).to be false }
-    end
+  it 'returns false for error?' do
+    expect(logger.error?).to be_falsey
+  end
+
+  it 'returns false for warn?' do
+    expect(logger.warn?).to be_falsey
+  end
+
+  it 'returns false for fatal?' do
+    expect(logger.fatal?).to be_falsey
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ require 'rake'
 
 # @return [Boolean] true if we run against jruby
 def jruby?
-  ENV['RUBY_VERSION'].include?('jruby')
+  ENV['RUBY_VERSION']&.include?('jruby')
 end
 
 # Don't include unnecessary stuff into rcov


### PR DESCRIPTION
Rather than use `method_missing` just define the methods and let ruby handle the rest naturally.